### PR TITLE
feat: Promote to v1.0.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - 2025-03-14
+
+### Initial stable release
+
+PR Conflict Detector is now considered stable and ready for production use.
+
+### Features
+
+- **Cross-repository conflict detection** - Scan an entire organization, a single repository, or a list of repositories for overlapping PR changes
+- **Line-level analysis** - Detects conflicts at the line range level, not just file overlap
+- **Same-author filtering** - Automatically excludes conflicts where both PRs are authored by the same person
+- **Conflict deduplication** - Tracks conflict history via GitHub Issues to only notify on new or changed conflicts
+- **Merge simulation verification** - Optionally verifies conflicts using GitHub's merge API (`VERIFY_CONFLICTS`)
+- **Draft PR support** - Optionally includes draft PRs in analysis (`INCLUDE_DRAFTS`)
+- **Author and team filtering** - Filter analysis to specific authors (`FILTER_AUTHORS`) or teams (`FILTER_TEAMS`)
+- **Multiple output formats**:
+  - Markdown report with GitHub Actions step summary
+  - JSON report for programmatic consumption
+  - GitHub Issues opened in affected repositories
+  - PR comments posted directly on conflicting PRs (`ENABLE_PR_COMMENTS`)
+  - Per-conflict Slack notifications with @mentions (`SLACK_WEBHOOK_URL`, `SLACK_CHANNEL`)
+- **Flexible authentication** - Supports GitHub App credentials, personal access tokens, and `GITHUB_TOKEN`
+- **GitHub Enterprise Server support** via `GH_ENTERPRISE_URL`
+- **Scalable** - Handles organizations with hundreds of open pull requests via pagination and rate limit awareness


### PR DESCRIPTION
## Summary

Promotes pr-conflict-detector to v1.0.0 stable release.

### What this PR does

Adds a `CHANGELOG.md` documenting all features in the initial stable release.

### What already points to v1

The codebase was written anticipating v1 - these are already in place on `main`:

- `action.yml` line 7: `docker://ghcr.io/github-community-projects/pr-conflict-detector:v1`
- `pyproject.toml` line 3: `version = "1.0.0"`
- All 4 README workflow examples: `@v1`

### What happens on merge

When this PR is merged with the `major` label:

1. **release-drafter** bumps from v0.2.0 → **v1.0.0** (major bump)
2. **release-image** builds and pushes Docker image tagged `v1.0.0` and `v1` to GHCR
3. **release-discussion** creates an announcement in the Discussions tab
4. The `v1` tag is created, making all existing `@v1` references in READMEs and action.yml resolve correctly

### Checklist

- [x] Add `major` label to this PR before merging