### PR TITLE
fix: prevent dev dependency downloads at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 
 ENV PYTHONUNBUFFERED=1
 CMD ["/action/workspace/pr_conflict_detector.py"]
-ENTRYPOINT ["uv", "run", "--project", "/action/workspace"]
+ENTRYPOINT ["uv", "run", "--no-dev", "--project", "/action/workspace"]


### PR DESCRIPTION
## Problem

The Dockerfile `ENTRYPOINT` uses `uv run` without `--no-dev`, causing it to re-sync the environment and download ~15MB of CI-only tools on every action invocation:

```
Downloading pygments (1.2MiB)
Downloading black (1.7MiB)
Downloading mypy (13.0MiB)
```

The build step correctly uses `uv sync --frozen --no-dev`, but `uv run` ignores that and resolves the full dependency graph including `[dependency-groups] dev`.

## Fix

One-line change - add `--no-dev` to the entrypoint:

```dockerfile
ENTRYPOINT ["uv", "run", "--no-dev", "--project", "/action/workspace"]
```

## Testing

- ✅ **Docker build** - Image builds successfully
- ✅ **Docker run (local)** - Tested against `github/new-user-experience` with `FILTER_TEAMS` and `DRY_RUN=true`. No dev dependency download lines in output. Action resolved teams, scanned PRs, completed successfully.
- ✅ **Before/after comparison**:
  - **Before**: `Downloading pygments (1.2MiB)`, `Downloading black (1.7MiB)`, `Downloading mypy (13.0MiB)` on every run
  - **After**: No downloads at startup, action runs immediately

Closes #40