### PR TITLE
fix: cast gh_app_id to string for JWT encoding compatibility

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -64,7 +64,7 @@ def auth_to_github(
         else:
             gh = github3.github.GitHub()
         gh.login_as_app_installation(
-            gh_app_private_key_bytes, gh_app_id, gh_app_installation_id
+            gh_app_private_key_bytes, str(gh_app_id), gh_app_installation_id
         )
         github_connection = gh
     elif ghe and token:

--- a/test_auth.py
+++ b/test_auth.py
@@ -59,9 +59,9 @@ class TestAuth(unittest.TestCase):
         mock = mock_ghe.return_value
         mock.login_as_app_installation = MagicMock(return_value=True)
         result = auth.auth_to_github(
-            "", "123", "123", b"123", "https://github.example.com", True
+            "", 123, 456, b"123", "https://github.example.com", True
         )
-        mock.login_as_app_installation.assert_called_once()
+        mock.login_as_app_installation.assert_called_once_with(b"123", "123", 456)
         self.assertEqual(result, mock)
 
     @patch("github3.github.GitHub")
@@ -72,9 +72,9 @@ class TestAuth(unittest.TestCase):
         mock = mock_gh.return_value
         mock.login_as_app_installation = MagicMock(return_value=True)
         result = auth.auth_to_github(
-            "", "123", "123", b"123", "https://github.example.com", False
+            "", 123, 456, b"123", "https://github.example.com", False
         )
-        mock.login_as_app_installation.assert_called_once()
+        mock.login_as_app_installation.assert_called_once_with(b"123", "123", 456)
         self.assertEqual(result, mock)
 
     @patch("github3.apps.create_jwt_headers", MagicMock(return_value="gh_token"))


### PR DESCRIPTION
## What

Cast gh_app_id to str() when passing it to login_as_app_installation, which internally calls jwt.encode expecting the iss claim to be a string. Updated tests to pass integer app IDs and assert the string conversion occurs.

## Why

Since v2.0.0, GitHub App authentication fails with "TypeError: Issuer (iss) must be a string" because newer versions of PyJWT enforce that the iss claim is a string, but gh_app_id was being passed as an integer.

## Notes

- Tests now use assert_called_once_with instead of assert_called_once to verify the exact arguments, preventing this class of regression
- Test inputs changed from strings to integers to mirror real-world usage where env vars are parsed as ints
- Relates to github-community-projects/evergreen#508