### PR TITLE
perf: filter PRs by author before fetching file changes

### DIFF
--- a/pr_conflict_detector.py
+++ b/pr_conflict_detector.py
@@ -80,21 +80,17 @@ def main():
         # Fetch all open PR data
         owner, repo_name = repo.full_name.split("/")
         prs = fetch_all_pr_data(
-            repo, env_vars.include_drafts, github_connection, owner, repo_name
+            repo,
+            env_vars.include_drafts,
+            github_connection,
+            owner,
+            repo_name,
+            filter_authors=combined_filter_authors or None,
         )
 
         # Filter exempt PRs
         if env_vars.exempt_prs:
             prs = [pr for pr in prs if pr.number not in env_vars.exempt_prs]
-
-        # Filter by author if configured (FILTER_AUTHORS and/or FILTER_TEAMS)
-        if combined_filter_authors:
-            prs = [pr for pr in prs if pr.author in combined_filter_authors]
-            if not prs:
-                print(
-                    f"  No PRs from filtered authors ({len(combined_filter_authors)} configured)"
-                )
-                continue
 
         if len(prs) < 2:
             print(f"  {len(prs)} open PR(s) - need at least 2 to detect conflicts")

--- a/pr_data.py
+++ b/pr_data.py
@@ -131,6 +131,7 @@ def fetch_all_pr_data(
     github_connection: object,
     owner: str,
     repo_name: str,
+    filter_authors: set[str] | None = None,
 ) -> list[PullRequestData]:
     """
     Fetch all open PRs and their changed files from a repository.
@@ -141,11 +142,24 @@ def fetch_all_pr_data(
         github_connection: The github3-py GitHub connection.
         owner: The repository owner.
         repo_name: The repository name.
+        filter_authors: If provided, only fetch file changes for PRs authored
+            by users in this set. PRs from other authors are excluded from the
+            returned list entirely. This avoids expensive per-PR API calls for
+            PRs that would be filtered out later.
 
     Returns:
         A list of PullRequestData objects with changed files populated.
     """
     prs = get_open_prs(repo, include_drafts)
+
+    if filter_authors:
+        before_count = len(prs)
+        prs = [pr for pr in prs if pr.author in filter_authors]
+        print(
+            f"  Filtered to {len(prs)} of {before_count} PRs "
+            f"by author ({len(filter_authors)} authors configured)"
+        )
+
     total = len(prs)
     if total == 0:
         return prs

--- a/test_pr_conflict_detector.py
+++ b/test_pr_conflict_detector.py
@@ -89,6 +89,22 @@ def _make_pr(number, title="PR title", author="dev"):
     )
 
 
+def _mock_fetch_with_filter(prs):
+    """Create a side_effect for fetch_all_pr_data that applies filter_authors.
+
+    This simulates the real fetch_all_pr_data behavior where filter_authors
+    is applied before fetching file changes.
+    """
+
+    def side_effect(*_args, **kwargs):
+        filter_authors = kwargs.get("filter_authors")
+        if filter_authors:
+            return [pr for pr in prs if pr.author in filter_authors]
+        return list(prs)
+
+    return side_effect
+
+
 def _mock_dedup_passthrough():
     """Create a mock deduplication module that passes conflicts through.
 
@@ -211,7 +227,9 @@ class TestMainWithOrganization(unittest.TestCase):
 
         mock_get_env.assert_called_once()
         mock_auth.assert_called_once()
-        mock_fetch.assert_called_once_with(repo, True, gh, "test-org", "repo-a")
+        mock_fetch.assert_called_once_with(
+            repo, True, gh, "test-org", "repo-a", filter_authors=None
+        )
         mock_detect.assert_called_once_with(
             [pr1, pr2],
             verify=False,
@@ -315,7 +333,7 @@ class TestSkipsExemptRepos(unittest.TestCase):
         # fetch_all_pr_data should only be called for the normal repo
         self.assertEqual(mock_fetch.call_count, 1)
         mock_fetch.assert_called_once_with(
-            normal_repo, True, gh, "test-org", "normal-repo"
+            normal_repo, True, gh, "test-org", "normal-repo", filter_authors=None
         )
 
 
@@ -359,7 +377,9 @@ class TestSkipsArchivedRepos(unittest.TestCase):
         main()
 
         self.assertEqual(mock_fetch.call_count, 1)
-        mock_fetch.assert_called_once_with(active, True, gh, "test-org", "active-repo")
+        mock_fetch.assert_called_once_with(
+            active, True, gh, "test-org", "active-repo", filter_authors=None
+        )
 
 
 @patch("pr_conflict_detector.deduplication", new=_mock_dedup_passthrough())
@@ -554,7 +574,7 @@ class TestFilterAuthors(unittest.TestCase):
         pr_alice = _make_pr(1, author="alice")
         pr_bob = _make_pr(2, author="bob")
         pr_charlie = _make_pr(3, author="charlie")
-        mock_fetch.return_value = [pr_alice, pr_bob, pr_charlie]
+        mock_fetch.side_effect = _mock_fetch_with_filter([pr_alice, pr_bob, pr_charlie])
         mock_detect.return_value = []
 
         main()
@@ -590,7 +610,7 @@ class TestFilterAuthors(unittest.TestCase):
 
         pr_bob = _make_pr(1, author="bob")
         pr_charlie = _make_pr(2, author="charlie")
-        mock_fetch.return_value = [pr_bob, pr_charlie]
+        mock_fetch.side_effect = _mock_fetch_with_filter([pr_bob, pr_charlie])
 
         main()
 
@@ -638,7 +658,7 @@ class TestFilterTeams(unittest.TestCase):
         pr_alice = _make_pr(1, author="alice")
         pr_bob = _make_pr(2, author="bob")
         pr_charlie = _make_pr(3, author="charlie")
-        mock_fetch.return_value = [pr_alice, pr_bob, pr_charlie]
+        mock_fetch.side_effect = _mock_fetch_with_filter([pr_alice, pr_bob, pr_charlie])
         mock_detect.return_value = []
 
         main()
@@ -684,7 +704,9 @@ class TestFilterTeams(unittest.TestCase):
         pr_bob = _make_pr(2, author="bob")
         pr_charlie = _make_pr(3, author="charlie")
         pr_dana = _make_pr(4, author="dana")
-        mock_fetch.return_value = [pr_alice, pr_bob, pr_charlie, pr_dana]
+        mock_fetch.side_effect = _mock_fetch_with_filter(
+            [pr_alice, pr_bob, pr_charlie, pr_dana]
+        )
         mock_detect.return_value = []
 
         main()
@@ -774,7 +796,9 @@ class TestFilterTeams(unittest.TestCase):
         pr_bob = _make_pr(2, author="bob")
         pr_charlie = _make_pr(3, author="charlie")
         pr_dana = _make_pr(4, author="dana")
-        mock_fetch.return_value = [pr_alice, pr_bob, pr_charlie, pr_dana]
+        mock_fetch.side_effect = _mock_fetch_with_filter(
+            [pr_alice, pr_bob, pr_charlie, pr_dana]
+        )
         mock_detect.return_value = []
 
         main()

--- a/test_pr_data.py
+++ b/test_pr_data.py
@@ -390,6 +390,101 @@ class TestFetchAllPrData(unittest.TestCase):
         args = mock_get_open_prs.call_args
         self.assertFalse(args[0][1])  # include_drafts=False
 
+    @patch("pr_data.get_open_prs")
+    def test_filter_authors_skips_file_fetch(self, mock_get_open_prs):
+        """When filter_authors is set, only matching PRs should have files fetched."""
+        pr_alice = PullRequestData(
+            number=1,
+            title="Alice PR",
+            author="alice",
+            html_url="url1",
+            is_draft=False,
+            base_branch="main",
+            head_branch="f-1",
+        )
+        pr_bob = PullRequestData(
+            number=2,
+            title="Bob PR",
+            author="bob",
+            html_url="url2",
+            is_draft=False,
+            base_branch="main",
+            head_branch="f-2",
+        )
+        pr_charlie = PullRequestData(
+            number=3,
+            title="Charlie PR",
+            author="charlie",
+            html_url="url3",
+            is_draft=False,
+            base_branch="main",
+            head_branch="f-3",
+        )
+        mock_get_open_prs.return_value = [pr_alice, pr_bob, pr_charlie]
+
+        mock_repo = MagicMock()
+        mock_full_pr = MagicMock()
+        mock_full_pr.files.return_value = [
+            _make_mock_file(filename="test.py", patch_str="@@ -1,2 +1,3 @@\n+x"),
+        ]
+        mock_repo.pull_request.return_value = mock_full_pr
+
+        result = fetch_all_pr_data(
+            mock_repo,
+            True,
+            MagicMock(),
+            "owner",
+            "repo",
+            filter_authors={"alice", "bob"},
+        )
+
+        # Only alice and bob returned
+        self.assertEqual(len(result), 2)
+        authors = {pr.author for pr in result}
+        self.assertEqual(authors, {"alice", "bob"})
+        # Only 2 API calls for files, not 3
+        self.assertEqual(mock_repo.pull_request.call_count, 2)
+
+    @patch("pr_data.get_open_prs")
+    def test_filter_authors_none_fetches_all(self, mock_get_open_prs):
+        """When filter_authors is None, all PRs should have files fetched."""
+        pr1 = PullRequestData(
+            number=1,
+            title="PR 1",
+            author="user1",
+            html_url="url1",
+            is_draft=False,
+            base_branch="main",
+            head_branch="f-1",
+        )
+        pr2 = PullRequestData(
+            number=2,
+            title="PR 2",
+            author="user2",
+            html_url="url2",
+            is_draft=False,
+            base_branch="main",
+            head_branch="f-2",
+        )
+        mock_get_open_prs.return_value = [pr1, pr2]
+
+        mock_repo = MagicMock()
+        mock_full_pr = MagicMock()
+        mock_full_pr.files.return_value = []
+        mock_repo.pull_request.return_value = mock_full_pr
+
+        result = fetch_all_pr_data(
+            mock_repo,
+            True,
+            MagicMock(),
+            "owner",
+            "repo",
+            filter_authors=None,
+        )
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(mock_repo.pull_request.call_count, 2)
+
 
 class TestDataClasses(unittest.TestCase):
     """Tests for the data classes."""


### PR DESCRIPTION
## Problem

When `FILTER_AUTHORS` or `FILTER_TEAMS` is configured, the action fetches file changes for **all** open PRs before filtering by author. For large repositories this wastes API calls on PRs that will be discarded.

Real-world example: `github/github` has ~1,500 open PRs but only ~60 match the configured team filter. The action was making ~1,500 file-fetch API calls (1 per PR), exhausting the 5,000 req/hr PAT rate limit before finishing a single repo.

## Solution

Move author filtering into `fetch_all_pr_data()` so it happens **before** the per-PR file-fetch loop. The lightweight PR listing (paginated, single API call) still fetches all open PRs, but only matching PRs trigger the expensive `repo.pull_request(number)` + `.files()` calls.

```
Before: list all PRs → fetch files for ALL → filter by author
After:  list all PRs → filter by author → fetch files for MATCHING only
```

The `filter_authors` parameter is optional (`None` by default), so users without `FILTER_AUTHORS`/`FILTER_TEAMS` are unaffected.

## Impact

For the `github/github` example:
- **Before**: ~1,500 file-fetch API calls → rate limit exhausted
- **After**: ~60 file-fetch API calls → well within limits

~96% reduction in API calls when author/team filtering is configured.

## Side effects

This optimization does not change which conflicts are found. The set of PRs reaching `detect_conflicts()` is identical before and after this change. Previously, `fetch_all_pr_data()` fetched file data for all ~1,500 PRs, then `pr_conflict_detector.py` filtered by author before passing the list to conflict detection. Now the author filter is applied earlier — before the per-PR file fetch — so the same PRs end up in `detect_conflicts()`, just without burning through API quota on PRs we were going to throw away anyway.

## Testing

- ✅ 235 tests passing (99.45% coverage)
- ✅ 2 new unit tests for `filter_authors` parameter in `test_pr_data.py`
- ✅ Updated 6 existing integration tests to use `_mock_fetch_with_filter()` helper
- ✅ Manual end-to-end testing against `github/super-linter` (2 open PRs, DRY_RUN=true):
  - `FILTER_AUTHORS="dependabot[bot]"` → `Filtered to 2 of 2 PRs by author` → both PRs processed ✅
  - `FILTER_AUTHORS="zkoppert"` → `Filtered to 0 of 2 PRs by author` → repo skipped correctly ✅
  - `FILTER_AUTHORS=""` (no filter) → all PRs fetched, no filter message → backward compat ✅