### PR TITLE
test: reach 100% coverage and enforce in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	uv run python -m pytest -v --cov=. --cov-config=.coveragerc --cov-fail-under=80 --cov-report term-missing
+	uv run python -m pytest -v --cov=. --cov-config=.coveragerc --cov-fail-under=100 --cov-report term-missing
 
 .PHONY: clean
 clean:

--- a/test_env.py
+++ b/test_env.py
@@ -463,7 +463,11 @@ class TestEnv(unittest.TestCase):
 
 
 class TestEnvFilterTeamsEdgeCases(unittest.TestCase):
-    """Edge cases for FILTER_TEAMS parsing kept separate to keep TestEnv focused."""
+    """Edge cases for FILTER_TEAMS parsing.
+
+    Lives in a sibling class (rather than TestEnv) so TestEnv stays under
+    pylint's max-public-methods threshold.
+    """
 
     def setUp(self):
         for key in ("ORGANIZATION", "GH_TOKEN", "FILTER_TEAMS"):

--- a/test_env.py
+++ b/test_env.py
@@ -462,5 +462,28 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(result.exclude_authors, [])
 
 
+class TestEnvFilterTeamsEdgeCases(unittest.TestCase):
+    """Edge cases for FILTER_TEAMS parsing kept separate to keep TestEnv focused."""
+
+    def setUp(self):
+        for key in ("ORGANIZATION", "GH_TOKEN", "FILTER_TEAMS"):
+            if key in os.environ:
+                del os.environ[key]
+
+    @patch.dict(
+        os.environ,
+        {
+            "ORGANIZATION": "my_organization",
+            "GH_TOKEN": "my_token",
+            "FILTER_TEAMS": "my-org/team-a, , my-org/team-b",
+        },
+        clear=True,
+    )
+    def test_filter_teams_skips_empty_comma_separated_entries(self):
+        """Empty entries between commas (after stripping whitespace) should be skipped."""
+        result = get_env_vars(True)
+        self.assertEqual(result.filter_teams, ["my-org/team-a", "my-org/team-b"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_pr_comment_posting.py
+++ b/test_pr_comment_posting.py
@@ -114,12 +114,17 @@ class TestPostPRComments(unittest.TestCase):
         gh = MagicMock()
         gh.repository.return_value = MagicMock()
 
-        # Pass new_conflict_keys to exercise the badge-computation branch
         new_keys = {(1, 2)}
         result = pr_comment.post_pr_comments(conflicts, gh, new_conflict_keys=new_keys)
 
         self.assertTrue(result)
         self.assertEqual(mock_post.call_count, 2)
+
+        # Each comment body should contain the 🆕 badge next to the OTHER PR.
+        # _post_comment(repo, pr_number, body) — pr_number=positional[1], body=positional[2].
+        bodies_by_pr = {call.args[1]: call.args[2] for call in mock_post.call_args_list}
+        self.assertIn("🆕", bodies_by_pr[1])
+        self.assertIn("🆕", bodies_by_pr[2])
 
     @patch("pr_comment._post_comment", return_value=True)
     @patch("pr_comment._find_existing_comments", return_value=[])
@@ -133,12 +138,17 @@ class TestPostPRComments(unittest.TestCase):
         gh = MagicMock()
         gh.repository.return_value = MagicMock()
 
-        # Reversed tuple should still match the conflict
+        # Only the reversed tuple is present — the disjunction's second half must fire.
         new_keys = {(2, 1)}
         result = pr_comment.post_pr_comments(conflicts, gh, new_conflict_keys=new_keys)
 
         self.assertTrue(result)
         self.assertEqual(mock_post.call_count, 2)
+
+        bodies_by_pr = {call.args[1]: call.args[2] for call in mock_post.call_args_list}
+        # Without the (other, pr_number) branch, neither body would contain 🆕.
+        self.assertIn("🆕", bodies_by_pr[1])
+        self.assertIn("🆕", bodies_by_pr[2])
 
     @patch("pr_comment._post_comment", return_value=False)
     @patch("pr_comment._find_existing_comments", return_value=[])

--- a/test_pr_comment_posting.py
+++ b/test_pr_comment_posting.py
@@ -104,6 +104,72 @@ class TestPostPRComments(unittest.TestCase):
         self.assertIn("#3", body)
         self.assertIn("**2**", body)
 
+    @patch("pr_comment._post_comment", return_value=True)
+    @patch("pr_comment._find_existing_comments", return_value=[])
+    def test_post_pr_comments_with_new_conflict_keys(self, _mock_find, mock_post):
+        """Newly detected conflicts should render with the 🆕 badge via new_conflict_keys."""
+        conflict = _make_comment_conflict()
+        conflicts = {"org/repo": [conflict]}
+
+        gh = MagicMock()
+        gh.repository.return_value = MagicMock()
+
+        # Pass new_conflict_keys to exercise the badge-computation branch
+        new_keys = {(1, 2)}
+        result = pr_comment.post_pr_comments(conflicts, gh, new_conflict_keys=new_keys)
+
+        self.assertTrue(result)
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("pr_comment._post_comment", return_value=True)
+    @patch("pr_comment._find_existing_comments", return_value=[])
+    def test_post_pr_comments_new_conflict_keys_reverse_pair(
+        self, _mock_find, mock_post
+    ):
+        """The reversed (other, pr_number) tuple should also be detected as new."""
+        conflict = _make_comment_conflict()
+        conflicts = {"org/repo": [conflict]}
+
+        gh = MagicMock()
+        gh.repository.return_value = MagicMock()
+
+        # Reversed tuple should still match the conflict
+        new_keys = {(2, 1)}
+        result = pr_comment.post_pr_comments(conflicts, gh, new_conflict_keys=new_keys)
+
+        self.assertTrue(result)
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch("pr_comment._post_comment", return_value=False)
+    @patch("pr_comment._find_existing_comments", return_value=[])
+    def test_post_pr_comments_post_failure_returns_false(self, _mock_find, _mock_post):
+        """If posting a new comment fails, the overall return should be False."""
+        conflict = _make_comment_conflict()
+        conflicts = {"org/repo": [conflict]}
+
+        gh = MagicMock()
+        gh.repository.return_value = MagicMock()
+
+        result = pr_comment.post_pr_comments(conflicts, gh)
+        self.assertFalse(result)
+
+    @patch("pr_comment._update_comment", return_value=False)
+    @patch("pr_comment._find_existing_comments")
+    def test_post_pr_comments_update_failure_returns_false(
+        self, mock_find, _mock_update
+    ):
+        """If updating an existing comment fails, the overall return should be False."""
+        conflict = _make_comment_conflict()
+        conflicts = {"org/repo": [conflict]}
+
+        mock_find.return_value = [MagicMock()]
+
+        gh = MagicMock()
+        gh.repository.return_value = MagicMock()
+
+        result = pr_comment.post_pr_comments(conflicts, gh)
+        self.assertFalse(result)
+
 
 class TestFindExistingComments(unittest.TestCase):
     """Tests for the _find_existing_comments function."""

--- a/test_slack_notify.py
+++ b/test_slack_notify.py
@@ -90,9 +90,17 @@ class TestSendSlackNotification(unittest.TestCase):
         )
         self.assertTrue(result)
 
+    @patch("slack_notify.cluster_conflicts", wraps=slack_notify.cluster_conflicts)
     @patch("slack_notify.post_to_slack", return_value=True)
-    def test_send_slack_notification_skips_repo_with_empty_list(self, mock_post):
-        """A repo with an empty conflict list mixed with non-empty repos is skipped."""
+    def test_send_slack_notification_skips_repo_with_empty_list(
+        self, mock_post, mock_cluster
+    ):
+        """A repo with an empty conflict list mixed with non-empty repos is skipped.
+
+        The `continue` at slack_notify.py:42-43 short-circuits before cluster_conflicts
+        is called, so a real skip is observable as cluster_conflicts being called once
+        (for the non-empty repo) rather than twice.
+        """
         conflicts = {
             "org/empty-repo": [],
             "org/repo": [_make_conflict()],
@@ -101,8 +109,10 @@ class TestSendSlackNotification(unittest.TestCase):
             "https://hooks.slack.com/test", conflicts
         )
         self.assertTrue(result)
-        # post_to_slack should only have been called for the non-empty repo
         self.assertEqual(mock_post.call_count, 1)
+        # cluster_conflicts must only run for the non-empty repo; deleting the
+        # `continue` would cause it to run twice (once with `[]`).
+        self.assertEqual(mock_cluster.call_count, 1)
 
     @patch("slack_notify.post_to_slack")
     def test_send_slack_notification_dry_run(self, mock_post):

--- a/test_slack_notify.py
+++ b/test_slack_notify.py
@@ -90,6 +90,20 @@ class TestSendSlackNotification(unittest.TestCase):
         )
         self.assertTrue(result)
 
+    @patch("slack_notify.post_to_slack", return_value=True)
+    def test_send_slack_notification_skips_repo_with_empty_list(self, mock_post):
+        """A repo with an empty conflict list mixed with non-empty repos is skipped."""
+        conflicts = {
+            "org/empty-repo": [],
+            "org/repo": [_make_conflict()],
+        }
+        result = slack_notify.send_slack_notification(
+            "https://hooks.slack.com/test", conflicts
+        )
+        self.assertTrue(result)
+        # post_to_slack should only have been called for the non-empty repo
+        self.assertEqual(mock_post.call_count, 1)
+
     @patch("slack_notify.post_to_slack")
     def test_send_slack_notification_dry_run(self, mock_post):
         """Dry-run mode should return True but never call post_to_slack."""


### PR DESCRIPTION
# Pull Request

## Proposed Changes

Test coverage was sitting at 99% with 8 uncovered lines spread across `env.py`, `pr_comment.py`, and `slack_notify.py`. Each gap was a real branch that could regress silently, and there was no CI guardrail preventing coverage from drifting further down over time.

I added six targeted unit tests so every line is now exercised, then bumped the pytest threshold so future regressions fail CI instead of being noticed later.

### What changed

- **`test_env.py`** - Added a FILTER_TEAMS case where a comma-separated value contains an empty middle entry (`"a, , b"`), confirming the parser skips it. The new case lives in a small `TestEnvFilterTeamsEdgeCases` class so `TestEnv` stays under pylint's `max-public-methods`.
- **`test_slack_notify.py`** - Added a case mixing a repo with zero conflicts and a repo with conflicts, so the per-repo skip branch is hit (the existing empty-conflict test took an earlier short-circuit).
- **`test_pr_comment_posting.py`** - Added four tests: forward and reverse `(pr_number, other)` lookups when `new_conflict_keys` is supplied, plus failure-path coverage for both `_update_comment` and `_post_comment` returning False.
- **`Makefile`** - Raised `--cov-fail-under` from 80 to 100 so any future drop in coverage fails CI.

### Impact

- Coverage: **99% → 100%** (8 uncovered lines → 0)
- Test count: **281 → 287** (+6)
- CI now blocks any drop below 100%

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

## Testing

- `make test` locally: 287 passed, 100.00% coverage, threshold check at 100% passes
- Verified each previously-uncovered line is now hit by inspecting the `term-missing` report (zero missing lines on every module)
- Sanity-checked the new pylint structure: `TestEnv` stays at 25 public methods, the new `TestEnvFilterTeamsEdgeCases` class isolates the new case so it does not regress the `too-many-public-methods` rule

## Rollout

No runtime behavior changes - the action's production code is untouched. The only behavioral change is in CI: a future PR that lowers coverage below 100% will fail `make test`. If that becomes too strict for a specific change, the threshold in the Makefile is the single knob to tune.
